### PR TITLE
Add environment variable credentials for lambda compatibility

### DIFF
--- a/src/main/scala/com/gu/mobiledatalakealerts/AwsCredentials.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/AwsCredentials.scala
@@ -1,18 +1,18 @@
 package com.gu.mobiledatalakealerts
 
-import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 object AwsCredentials {
 
   val athenaCredentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("ophan")
-  // FIXME Add correct credentials provider for a lambda
+    new ProfileCredentialsProvider("ophan"),
+    new EnvironmentVariableCredentialsProvider()
   )
 
   val notificationCredentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("mobile")
-  // FIXME Add correct credentials provider for a lambda
+    new ProfileCredentialsProvider("mobile"),
+    new EnvironmentVariableCredentialsProvider()
   )
 
 }


### PR DESCRIPTION
This should allow the correct credentials to be loaded within a lambda (currently it has just been running locally).