### PR TITLE
Refactor and temporarily remove beta functionality

### DIFF
--- a/src/main/scala/com/gu/mobiledatalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Athena.scala
@@ -16,9 +16,9 @@ object Athena {
     .withCredentials(AwsCredentials.athenaCredentials)
     .build()
 
-  def startQuery(query: MonitoringQuery): StartQueryExecutionResult = {
+  def startQuery(monitoringQuery: MonitoringQuery): StartQueryExecutionResult = {
     val startQueryRequest: StartQueryExecutionRequest = new StartQueryExecutionRequest()
-      .withQueryString(query.query)
+      .withQueryString(monitoringQuery.query)
       .withResultConfiguration(new ResultConfiguration().withOutputLocation("s3://aws-athena-query-results-021353022223-eu-west-1")) // Ophan temp bucket
     client.startQueryExecution(startQueryRequest)
   }

--- a/src/main/scala/com/gu/mobiledatalakealerts/AwsCredentials.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/AwsCredentials.scala
@@ -1,18 +1,16 @@
 package com.gu.mobiledatalakealerts
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider}
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider }
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 object AwsCredentials {
 
   val athenaCredentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("ophan"),
-    new EnvironmentVariableCredentialsProvider()
-  )
+    new EnvironmentVariableCredentialsProvider())
 
   val notificationCredentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("mobile"),
-    new EnvironmentVariableCredentialsProvider()
-  )
+    new ProfileCredentialsProvider("developerPlayground"),
+    new EnvironmentVariableCredentialsProvider())
 
 }

--- a/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
@@ -56,9 +56,9 @@ object Features {
       val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
       val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
 
-      val additionalDebugInfo = if (resultIsAcceptable) Some {
+      val additionalDebugInfo = if (!resultIsAcceptable) Some {
         s"""
-           |Expected there to be at least $minimumImpressionsThreshold, but only got $totalImpressions
+           |Expected there to be at least $minimumImpressionsThreshold, but only got $totalImpressions.
          """.stripMargin
       }
       else {

--- a/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
@@ -58,7 +58,7 @@ object Features {
 
       val additionalDebugInfo = if (!resultIsAcceptable) Some {
         s"""
-           |Expected there to be at least $minimumImpressionsThreshold, but only got $totalImpressions.
+           |Expected there to be at least $minimumImpressionsThreshold impressions, but only found $totalImpressions impressions.
          """.stripMargin
       }
       else {

--- a/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
@@ -42,7 +42,7 @@ object Features {
         |group by 1""".stripMargin
 
       val minimumImpressionsThreshold = platform match {
-        case Android => 100 //FIXME
+        case Android => 35000
         case iOS => 40000
       }
 

--- a/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Features.scala
@@ -2,7 +2,8 @@ package com.gu.mobiledatalakealerts
 
 import java.time.LocalDate
 
-import com.gu.mobiledatalakealerts.Platforms.Platform
+import com.amazonaws.services.athena.model.ResultSet
+import com.gu.mobiledatalakealerts.Platforms.{ Android, Platform }
 
 object Features {
 
@@ -15,29 +16,58 @@ object Features {
       .getOrElse(throw new RuntimeException(s"Invalid feature specified: features with monitoring are ${allFeaturesWithMonitoring.map(_.id)}"))
   }
 
-  case class MonitoringQuery(query: String, minimumThresholdInBeta: Int)
+  case class MonitoringQuery(query: String, minimumImpressionsThreshold: Int)
+  case class MonitoringQueryResult(resultIsAcceptable: Boolean, additionalDebugInformation: Option[String])
+
   sealed trait Feature {
     val id: String
-    def query(latestBetaPrefix: String, platform: Platform): MonitoringQuery
+    def monitoringQuery(platform: Platform): MonitoringQuery
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult
   }
 
   case object FrictionScreen extends Feature {
 
     val id = "friction_screen"
 
-    def query(latestBetaPrefix: String, platform: Platform): MonitoringQuery = MonitoringQuery(
-      query = s"""
+    def monitoringQuery(platform: Platform): MonitoringQuery = {
+
+      val query = s"""
         |select browser_version, count (distinct page_view_id) as friction_screen_impressions
         |from clean.pageview
         |cross join unnest (component_events) x (c)
-        |where received_date >= date '$yesterday'
+        |where received_date = date '$yesterday'
         |and device_type like '%${platform.id.toUpperCase}%'
         |and c.component.type like '%APP_SCREEN%'
         |and c.component.campaign_code like '%friction%' and c.component.campaign_code like '%subscription_screen%'
-        |and browser_version like '$latestBetaPrefix%'
-        |group by 1
-      """.stripMargin,
-      minimumThresholdInBeta = 100)
+        |group by 1""".stripMargin
+
+      val minimumImpressionsThreshold = platform match {
+        case Android => 100 //FIXME
+        case iOS => 40000
+      }
+
+      MonitoringQuery(query, minimumImpressionsThreshold)
+
+    }
+
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
+
+      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
+      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
+      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
+
+      val additionalDebugInfo = if (resultIsAcceptable) Some {
+        s"""
+           |Expected there to be at least $minimumImpressionsThreshold, but only got $totalImpressions
+         """.stripMargin
+      }
+      else {
+        None
+      }
+
+      MonitoringQueryResult(resultIsAcceptable, additionalDebugInfo)
+
+    }
 
   }
 

--- a/src/main/scala/com/gu/mobiledatalakealerts/Lambda.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Lambda.scala
@@ -80,6 +80,8 @@ object Lambda {
     val monitoringResult = feature.monitoringQueryResult(Athena.retrieveResult(queryExecutionId), monitoringQuery.minimumImpressionsThreshold)
     if (!monitoringResult.resultIsAcceptable) {
       Notifications.alert(feature.id, monitoringResult.additionalDebugInformation, Stack(platform.id))
+    } else {
+      logger.info(s"Monitoring ran successfully for ${feature.id}. No problems were detected.")
     }
   }
 

--- a/src/main/scala/com/gu/mobiledatalakealerts/Lambda.scala
+++ b/src/main/scala/com/gu/mobiledatalakealerts/Lambda.scala
@@ -50,9 +50,8 @@ object Notifications {
       channel = Email,
       target = List(stack),
       actions = List(Action(
-        cta = "View Query Results",
-        url = s"https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#query/history/${executionId}")
-      ),
+        cta = "View Query Results [Requires Ophan AWS Console Access]",
+        url = s"https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#query/history/${executionId}")),
       topicArn = env.snsTopicForAlerts,
       client = AWS.snsClient(AwsCredentials.notificationCredentials))
 


### PR DESCRIPTION
Coping with beta versions is proving trickier than I expected, so I've decided to get this running for production versions first.

This PR removes any beta specific code. It also refactors things slightly, to incorporate @alexduf's suggestion that the function for checking query results is located with the query (inside `Feature`).